### PR TITLE
Make selected citations more prominent

### DIFF
--- a/solenoid/records/helpers.py
+++ b/solenoid/records/helpers.py
@@ -44,5 +44,5 @@ class Headers(object):
     #   from other data; alternately, we don't need the other data if we have a
     #   citation. The Record model will check for this.
     REQUIRED_DATA = list(set(EXPECTED_HEADERS) -
-                         set(AUTHOR_DATA) - {DOI} - {MESSAGE} - {CITATION}
-                         - {TITLE} - {JOURNAL} - {VOLUME} - {ISSUE})
+                         set(AUTHOR_DATA) - {DOI} - {MESSAGE} - {CITATION} -
+                         {TITLE} - {JOURNAL} - {VOLUME} - {ISSUE})

--- a/solenoid/records/templates/records/_unsent_list.html
+++ b/solenoid/records/templates/records/_unsent_list.html
@@ -1,14 +1,15 @@
 <div class="layout-3q1q">
   <div class="col3q">
-    <form method="POST" action="{% url 'emails:create' %}">
+    <form method="POST" action="{% url 'emails:create' %}" id="citations">
       {% csrf_token %}
       {% for record in object_list  %}
         <div class="checkbox dlc-{{ record.dlc|slugify }}">
           <label>
             <input class="input_author_{{ record.author.pk }} input_dlc_{{ record.author.dlc.pk }}" type="checkbox" name="records" value={{ record.pk }}> <strong>{{ record.author.dlc }} / {{ record.author.last_name}}</strong>
-            <br>
-            {{ record.citation }}
-            <hr>
+            <span>
+              <br>
+              {{ record.citation }}
+            </span>
           </label>
         </div>
       {% endfor %}
@@ -47,14 +48,23 @@
 
   function uncheck(checkboxes) {
     for (var i = 0; i < checkboxes.length; i++) {
-       checkboxes[i].removeAttribute('checked');
+       checkboxes[i].checked = false;
+       // Remove the class on the surrounding div so that we no longer have a
+       // background color.
+       findContainingDiv(checkboxes[i]).classList.remove('checked');
     }
   }
 
   function check(checkboxes) {
     for (var i = 0; i < checkboxes.length; i++) {
-       checkboxes[i].setAttribute('checked', 'checked');
+       checkboxes[i].checked = true;
+       findContainingDiv(checkboxes[i]).classList.add('checked');
     }
+  }
+
+  function findContainingDiv (el) {
+    while ((el = el.parentNode) && el.className.indexOf('checkbox') < 0);
+    return el;
   }
 
   var toggler = function (obj, prefix) {
@@ -87,4 +97,20 @@
 
   author_toggle.addEventListener('click', author_toggler, false);
   dlc_toggle.addEventListener('click', dlc_toggler, false);
+
+  // Set the class that toggles the background color when users click the label
+  // directly.
+  var input_toggler = function () {
+    if (this.checked) {
+      findContainingDiv(this).classList.add('checked');
+    } else {
+      findContainingDiv(this).classList.remove('checked');
+    }
+  }
+
+  var inputs = document.getElementById('citations').getElementsByTagName('input');
+  for (var k = 0; k < inputs.length; k++) {
+    inputs[k].addEventListener('click', input_toggler, false);
+  }
+
 </script>

--- a/solenoid/records/tests/tests.py
+++ b/solenoid/records/tests/tests.py
@@ -502,6 +502,7 @@ class RecordModelTest(TestCase):
             Headers.RECORD_ID: '98573'
         }
 
+    # need to actually test create_citation
     def test_is_row_valid_yes_citation_no_citation_data(self):
         row = copy.copy(self.csv_row)
         row[Headers.CITATION] = 'This is a citation'

--- a/solenoid/static/sass/apps/_solenoid.scss
+++ b/solenoid/static/sass/apps/_solenoid.scss
@@ -110,6 +110,19 @@ input:disabled {
   }
 }
 
+form .checkbox {
+  padding: 2rem 0.5rem;
+  border-bottom: 2px solid $gray-l1;
+
+  &.checked {
+    background-color: white;
+  }
+
+  &:last-of-type {
+    margin-bottom: 2rem;
+  }
+}
+
 .field-email {
   @extend .field-text;
 }


### PR DESCRIPTION
Users expressed concern that it may be hard to see status on a long
list of citations. We don't want to show/hide citations at this stage
because that may lead to confusing interactions; instead, we will
highlight selected to make status easier to see, and await user
reactions.

Fixes #58.