### PR TITLE
Test new static pipeline settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 todo.md
 solenoid/records/tests/csv/original.csv
-staticfiles/
+staticfiles/*
+!staticfiles/.gitkeep
+!staticfiles/CACHE/.gitkeep
 wireframes/
 node_modules
 build/*.js

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-release: python manage.py migrate
 web: newrelic-admin run-program gunicorn solenoid.wsgi --worker-class gevent --log-file -

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo "-----> Post-compile starting"
+python manage.py migrate
+# Don't use the release phase for compression because it's
+# "Not suggested for asset compilation or other tasks requiring filesystem persistence"
+# per https://devcenter.heroku.com/articles/release-phase .
+python manage.py compress
+python manage.py collectstatic --noinput
+echo "-----> Post-compile done"

--- a/solenoid/settings/heroku.py
+++ b/solenoid/settings/heroku.py
@@ -39,6 +39,9 @@ MIDDLEWARE_CLASSES += (
     'whitenoise.middleware.WhiteNoiseMiddleware',
 )
 
+COMPRESS_ENABLED = True
+COMPRESS_OFFLINE = True
+
 # LOGGING CONFIGURATION
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
I'd found that flipping debug to False worked briefly, but didn't
stick. Hypothesis: the problem is that we're not actually compressing
assets, so once the stylesheet cycles out of the browser cache we lose.
Additionally, adding compress to the release phase isn't good enough
because we also need to collect those assets (and the collection phase
may happen before the release tasks?)

Anyway. Try force-enabling offline compression on servers, and then
explicitly compressing and collecting during the release phase.