### PR TITLE
Update Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
+dist: xenial
 language: python
-python:
-  - "3.6"
-install:
-  - "pip install pipenv"
-  - "pip install coveralls"
-  - "pipenv install"
-  - "pipenv check"
-script:
-  coverage run manage.py test
-after_success:
-  coveralls
 services:
   - postgresql
+python: 3.7
+env:
+  - PIPENV_IGNORE_VIRTUALENVS=1
+before_install: pip install pipenv coveralls
+install: pipenv install --dev
+jobs:
+  include:
+    - name: Tests
+      script: pipenv run coverage run manage.py test
+      after_success: coveralls
+    - name: "PEP 508"
+      script: pipenv check


### PR DESCRIPTION
This fixes a few problems with the current Travis config. First it
forces pipenv to create a new virtualenv, rather than using the
virtualenv provided by Travis, which is problematic. Next it splits out
the pipenv check from the tests and runs them in parallel.