### PR TITLE
Add command to delete old ElementsAPICall records from the database

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ python_version = "3.7"
 
 [dev-packages]
 coverage = ">=4.5.1"
+freezegun = "*"
 
 [packages]
 # Only needed for Heroku

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a0e77934b83bb2f2e8de9c89cb75b78d030d86ff67bfdca1a1bc5194d3dd3568"
+            "sha256": "0b0c58d6096de05138af85abb12fe050e09ca8ebea8140db44ca3e6a8dc19279"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -59,11 +59,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:16a5d54411599780ac9dfe3b9b38f90f785c51259a584e0b24b6f14a7f69aae8",
-                "sha256:9a2f98211ab474c710fcdad29c82f30fc14ce9917c7a70c3682162a624de4035"
+                "sha256:148a4a2d1a85b23883b0a4e99ab7718f518a83675e4485e44dc0c1d36988c5fa",
+                "sha256:deb70aa038e59b58593673b15e9a711d1e5ccd941b5973b30750d5d026abfd56"
             ],
             "index": "pypi",
-            "version": "==2.2.4"
+            "version": "==2.2.5"
         },
         "django-appconf": {
             "hashes": [
@@ -155,10 +155,10 @@
         },
         "newrelic": {
             "hashes": [
-                "sha256:96cc8d37127f84718fa9a93f19648b3b8287267c9ceb1386d0ff9dc47e5859f3"
+                "sha256:9d6d3bf2e125410d485fd91279e1b0f50e8f0f5887284b345aed4ec81db33c0a"
             ],
             "index": "pypi",
-            "version": "==5.0.0.124"
+            "version": "==5.0.2.126"
         },
         "oauthlib": {
             "hashes": [
@@ -331,10 +331,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:72b5f1aea9101cf720a36bb2327ede866fd6f1a07b1e87c92a1cc18113cbc946",
-                "sha256:e4e9c053d59795e440163733a7fec6c5972210e1790c507e4c7b051d6c5259de"
+                "sha256:8662843366b8d8779dec4e2f921bebec9afd856a5ff2e82cd419acc5054a1a92",
+                "sha256:a5a6166b4767725fd52ae55fee8c8b6137d9a51e9f1edea461a062a759160118"
             ],
-            "version": "==1.9.2"
+            "version": "==1.9.3"
         },
         "sqlparse": {
             "hashes": [
@@ -397,6 +397,28 @@
             ],
             "index": "pypi",
             "version": "==4.5.4"
+        },
+        "freezegun": {
+            "hashes": [
+                "sha256:2a4d9c8cd3c04a201e20c313caf8b6338f1cfa4cda43f46a94cc4a9fd13ea5e7",
+                "sha256:edfdf5bc6040969e6ed2e36eafe277963bdc8b7c01daeda96c5c8594576c9390"
+            ],
+            "index": "pypi",
+            "version": "==0.3.12"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         }
     }
 }

--- a/solenoid/elements/management/commands/delete_stale_api_calls.py
+++ b/solenoid/elements/management/commands/delete_stale_api_calls.py
@@ -1,0 +1,21 @@
+from datetime import timedelta
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from solenoid.elements.models import ElementsAPICall
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = ('Deletes successfully sent ElementsAPICall records from the '
+            'database if they are more than 4 weeks old')
+
+    def handle(self, *args, **options):
+        last_month = timezone.now() - timedelta(weeks=4)
+        ElementsAPICall.objects.filter(
+            response_status='200'
+            ).filter(timestamp__lt=last_month).delete()


### PR DESCRIPTION
Plan is to run this command regularly in Heroku so we no longer have to delete old entries manually.