### PR TITLE
Update data import filters

### DIFF
--- a/solenoid/elements/tests/test_xml_handlers.py
+++ b/solenoid/elements/tests/test_xml_handlers.py
@@ -1,3 +1,4 @@
+import datetime
 import xml.etree.ElementTree as ET
 
 from freezegun import freeze_time
@@ -28,7 +29,11 @@ def test_make_xml(patch_xml):
 
 
 def test_parse_author_pubs_xml(author_pubs_xml):
-    pubs = parse_author_pubs_xml([author_pubs_xml])
+    author_data = {
+        'Start Date': datetime.date(2011, 10, 1),
+        'End Date': datetime.date(2020, 6, 30)
+    }
+    pubs = parse_author_pubs_xml([author_pubs_xml], author_data)
     assert pubs == [{'id': '2',
                     'title': 'Publication Two'}]
 
@@ -40,7 +45,9 @@ def test_parse_author_xml(author_xml):
         'First Name': 'Person',
         'Last Name': 'Author',
         'MIT ID': 'MITID',
-        'DLC': 'Department Faculty'
+        'DLC': 'Department Faculty',
+        'Start Date': datetime.date(2011, 10, 1),
+        'End Date': datetime.date(2020, 6, 30)
     }
 
 

--- a/solenoid/fixtures/author-pubs-feed.xml
+++ b/solenoid/fixtures/author-pubs-feed.xml
@@ -184,4 +184,34 @@
       </api:object>
     </api:related>
   </entry>
+  <entry>
+    <api:related direction="from" category="publication" id="5">
+      <api:object
+        category="publication"
+        id="5"
+        last-affected-when="2020-01-06T22:24:50.733-05:00"
+        last-modified-when="2020-01-06T22:24:50.733-05:00"
+        href="https://org-url:port/secure-api/v5.5/publications/4"
+        created-when="2016-11-11T10:32:09.993-05:00"
+        type-id="5"
+        type="journal-article">
+        <api:records>
+          <api:record>
+            <api:native>
+              <api:field name="title" type="text" display-name="Title">
+                <api:text>Publication Five</api:text>
+              </api:field>
+              <api:field name="publication-date" type="date" display-name="Publication date">
+                <api:date>
+                  <api:day>1</api:day>
+                  <api:month>1</api:month>
+                  <api:year>2010</api:year>
+                </api:date>
+              </api:field>
+            </api:native>
+          </api:record>
+        </api:records>
+      </api:object>
+    </api:related>
+  </entry>
 </feed>

--- a/solenoid/records/models.py
+++ b/solenoid/records/models.py
@@ -116,14 +116,7 @@ class Record(models.Model):
             first_init=paper_data[Fields.FIRST_NAME][0])
 
         if paper_data[Fields.PUBDATE]:
-            # We expect that the pubdate is a yyyymmdd string. If it isn't,
-            # don't guess, and don't add a publication year.
-            try:
-                assert re.compile("^\d{8}$").match(paper_data[Fields.PUBDATE])
-                citation += '({year}). '.format(
-                    year=paper_data[Fields.PUBDATE][0:4])
-            except AssertionError:
-                pass
+            citation += f'({paper_data[Fields.PUBDATE][0:4]}). '
 
         citation += '{title}. {journal}'.format(
             title=paper_data[Fields.TITLE],

--- a/solenoid/records/tests/test_models.py
+++ b/solenoid/records/tests/test_models.py
@@ -431,34 +431,6 @@ class RecordModelTest(TestCase):
             'Wilczek, F. Ultraviolet behavior of non-abelian gauge theories. Physical Review Letters.'  # noqa
         )
 
-    def test_create_citation_error_case_3(self):
-        """Minimal citation and pubdate, but pubdate is incorrectly formatted
-        (too few characters)."""
-        data = copy.copy(self.citation_data)
-        data.update(dict.fromkeys([Fields.VOLUME,
-                                   Fields.ISSUE,
-                                   Fields.DOI],
-                    None))
-        data[Fields.PUBDATE] = '12341'
-        citation = Record.create_citation(data)
-        self.assertEqual(citation,
-            'Wilczek, F. Ultraviolet behavior of non-abelian gauge theories. Physical Review Letters.'  # noqa
-        )
-
-    def test_create_citation_error_case_4(self):
-        """Minimal citation and pubdate, but pubdate is incorrectly formatted
-        (not all numbers)."""
-        data = copy.copy(self.citation_data)
-        data.update(dict.fromkeys([Fields.VOLUME,
-                                   Fields.ISSUE,
-                                   Fields.DOI],
-                    None))
-        data[Fields.PUBDATE] = '1234m714'
-        citation = Record.create_citation(data)
-        self.assertEqual(citation,
-            'Wilczek, F. Ultraviolet behavior of non-abelian gauge theories. Physical Review Letters.'  # noqa
-        )
-
     def test_update_if_needed_case_1(self):
         """update_if_needed alters the record when it sees a new author."""
         r1 = Record.objects.get(pk=1)

--- a/solenoid/records/views.py
+++ b/solenoid/records/views.py
@@ -191,7 +191,7 @@ class Import(ConditionalLoginRequiredMixin, FormView):
                 return super(Import, self).form_invalid(form)
         author_data = parse_author_xml(author_xml)
         pub_ids = parse_author_pubs_xml(
-            get_paged(f'{author_url}/publications?&detail=full'))
+            get_paged(f'{author_url}/publications?&detail=full'), author_data)
 
         for paper in pub_ids:
             paper_id = paper['id']


### PR DESCRIPTION
#### What does this PR do?
Fixes logic in the data import process to match our requirements: ensure a given paper was published during the author's faculty employment at MIT, and ensure the publication year is included in the citation if we have to generate the citation on import.

#### How can a reviewer see these changes?
Run the tests, or import an author from staging Elements (10897 works as a sample author ID) and check that publications outside the author's employed date range are excluded and citations include a publication year.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [x] The commit message is clear and follows our guidelines
- [x] There are tests covering any new functionality
- NA The documentation has been updated if necessary
- [x] The changes, if applicable, have been verified
