### PR TITLE
Fix bug in publication date parsing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,11 @@ def publication_new_xml():
 
 
 @pytest.fixture()
+def publication_no_date_xml():
+    return _get_file('publication-no-date.xml')
+
+
+@pytest.fixture()
 def publication_updated_xml():
     return _get_file('publication-updated.xml')
 
@@ -91,6 +96,7 @@ def mock_elements(author_xml, author_new_xml, author_pubs_xml,
                   fun_publication_emoji_xml, fun_publication_math_xml,
                   fun_publication_nonroman_xml,
                   publication_xml, publication_new_xml,
+                  publication_no_date_xml,
                   publication_updated_xml):
     with requests_mock.Mocker() as m:
         m.get('mock://api.com', text='Success')
@@ -113,6 +119,7 @@ def mock_elements(author_xml, author_new_xml, author_pubs_xml,
         m.get(f'mock://api.com/publications/2', text=publication_xml)
         m.get(f'mock://api.com/publications/2-updated',
               text=publication_updated_xml)
+        m.get(f'mock://api.com/publications/6', text=publication_no_date_xml)
 
         m.get(f'mock://api.com/users/fun', text=fun_author_xml)
         m.get(f'mock://api.com/users/fun/'

--- a/solenoid/elements/tests/test_xml_handlers.py
+++ b/solenoid/elements/tests/test_xml_handlers.py
@@ -29,6 +29,12 @@ def test_get_pub_date(publication_xml):
     assert date == datetime.date(2017, 2, 1)
 
 
+def test_get_pub_date_no_date(publication_no_date_xml):
+    pub_root = ET.fromstring(publication_no_date_xml)
+    date = get_pub_date(pub_root)
+    assert date is None
+
+
 @freeze_time('20190101')
 def test_make_xml(patch_xml):
     xml = make_xml('username')
@@ -41,8 +47,8 @@ def test_parse_author_pubs_xml(author_pubs_xml):
         'End Date': datetime.date(2020, 6, 30)
     }
     pubs = parse_author_pubs_xml([author_pubs_xml], author_data)
-    assert pubs == [{'id': '2',
-                    'title': 'Publication Two'}]
+    assert pubs == [{'id': '2', 'title': 'Publication Two'},
+                    {'id': '6', 'title': 'Publication Six'}]
 
 
 def test_parse_author_xml(author_xml):

--- a/solenoid/elements/tests/test_xml_handlers.py
+++ b/solenoid/elements/tests/test_xml_handlers.py
@@ -3,7 +3,8 @@ import xml.etree.ElementTree as ET
 
 from freezegun import freeze_time
 
-from solenoid.elements.xml_handlers import (extract_field, make_xml,
+from solenoid.elements.xml_handlers import (extract_field, get_pub_date,
+                                            make_xml,
                                             parse_author_pubs_xml,
                                             parse_author_xml, parse_paper_xml)
 
@@ -20,6 +21,12 @@ def test_extract_field_not_exists(publication_xml):
     pub_root = ET.fromstring(publication_xml)
     field = extract_field(pub_root, 'notafield')
     assert field == ''
+
+
+def test_get_pub_date(publication_xml):
+    pub_root = ET.fromstring(publication_xml)
+    date = get_pub_date(pub_root)
+    assert date == datetime.date(2017, 2, 1)
 
 
 @freeze_time('20190101')

--- a/solenoid/elements/xml_handlers.py
+++ b/solenoid/elements/xml_handlers.py
@@ -19,8 +19,11 @@ def extract_field(root, search_string):
 
 
 def get_pub_date(root):
-    year = int(extract_field(root, ".//api:field[@name='publication-date']"
-                             "//api:year"))
+    try:
+        year = int(extract_field(root, ".//api:field[@name='publication-date']"
+                                 "//api:year"))
+    except ValueError:
+        return None
     try:
         month = int(extract_field(root,
                                   ".//api:field[@name='publication-date']"
@@ -70,10 +73,12 @@ def parse_author_pubs_xml(xml_gen, author_data):
         for entry in root.findall("./atom:entry", NS):
             # Filter for papers to be requested based on various criteria
             pub_date = get_pub_date(entry)
-            if pub_date <= dt.date(2009, 3, 18):
+            if not pub_date:
+                pass
+            elif pub_date <= dt.date(2009, 3, 18):
                 continue
-            if not (pub_date >= author_data['Start Date'] and
-                    pub_date <= author_data['End Date']):
+            elif (pub_date < author_data['Start Date'] or
+                  pub_date > author_data['End Date']):
                 continue
             if entry.find(".//api:library-status", NS):
                 continue

--- a/solenoid/elements/xml_handlers.py
+++ b/solenoid/elements/xml_handlers.py
@@ -19,12 +19,19 @@ def extract_field(root, search_string):
 
 
 def get_pub_date(root):
-    year = int(root.find(".//api:field[@name='publication-date']"
-                         "//api:year", NS).text)
-    month = int(root.find(".//api:field[@name='publication-date']"
-                          "//api:month", NS).text)
-    day = int(root.find(".//api:field[@name='publication-date']"
-                        "//api:day", NS).text)
+    year = int(extract_field(root, ".//api:field[@name='publication-date']"
+                             "//api:year"))
+    try:
+        month = int(extract_field(root,
+                                  ".//api:field[@name='publication-date']"
+                                  "//api:month"))
+    except ValueError:
+        month = 1
+    try:
+        day = int(extract_field(root, ".//api:field[@name='publication-date']"
+                                "//api:day"))
+    except ValueError:
+        day = 1
     pub_date = dt.date(year, month, day)
     return pub_date
 

--- a/solenoid/fixtures/author-pubs-feed.xml
+++ b/solenoid/fixtures/author-pubs-feed.xml
@@ -162,23 +162,6 @@
               </api:field>
             </api:native>
           </api:record>
-          <api:record format="native" id="0000" source-id="1" source-name="manual" source-display-name="Manual" id-at-source="1111">
-            <api:verification-status>unverified</api:verification-status>
-            <api:native>
-              <api:field name="c-do-not-request" type="boolean" display-name="DoNotRequest">
-                <api:boolean>false</api:boolean>
-              </api:field>
-              <api:field name="c-optout" type="boolean" display-name="OptOut">
-                <api:boolean>false</api:boolean>
-              </api:field>
-              <api:field name="c-received" type="boolean" display-name="Received">
-                <api:boolean>false</api:boolean>
-              </api:field>
-              <api:field name="c-requested" type="boolean" display-name="Requested">
-                <api:boolean>false</api:boolean>
-              </api:field>
-            </api:native>
-          </api:record>
         </api:records>
       </api:object>
     </api:related>
@@ -206,6 +189,29 @@
                   <api:month>1</api:month>
                   <api:year>2010</api:year>
                 </api:date>
+              </api:field>
+            </api:native>
+          </api:record>
+        </api:records>
+      </api:object>
+    </api:related>
+  </entry>
+  <entry>
+    <api:related direction="from" category="publication" id="6">
+      <api:object
+        category="publication"
+        id="6"
+        last-affected-when="2020-01-06T22:24:50.733-05:00"
+        last-modified-when="2020-01-06T22:24:50.733-05:00"
+        href="https://org-url:port/secure-api/v5.5/publications/4"
+        created-when="2016-11-11T10:32:09.993-05:00"
+        type-id="5"
+        type="journal-article">
+        <api:records>
+          <api:record>
+            <api:native>
+              <api:field name="title" type="text" display-name="Title">
+                <api:text>Publication Six</api:text>
               </api:field>
             </api:native>
           </api:record>

--- a/solenoid/fixtures/author-pubs-feed.xml
+++ b/solenoid/fixtures/author-pubs-feed.xml
@@ -56,8 +56,7 @@
               </api:field>
               <api:field name="publication-date" type="date" display-name="Publication date">
                 <api:date>
-                  <api:day>1</api:day>
-                  <api:month>1</api:month>
+                  <api:month>2</api:month>
                   <api:year>2013</api:year>
                 </api:date>
               </api:field>

--- a/solenoid/fixtures/publication-no-date.xml
+++ b/solenoid/fixtures/publication-no-date.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:api="http://www.symplectic.co.uk/publications/api">
+  <api:schema-version>5.5</api:schema-version><category scheme="http://www.symplectic.co.uk/publications/atom/feeds/" term="item" label="Item"/>
+  <id>tag:elements@organisation,5.16:/secure-api/v5.5/feeds/publications/12345</id>
+  <updated>2020-02-03T22:35:51.08-05:00</updated>
+  <generator uri="https://org-url" version="5.16">Symplectic Elements</generator>
+  <icon>https://org-url:port/secure-api/v5.5/symplectic.ico</icon>
+  <rights>This data is the property of the Organisation, and can only be used with permission.</rights>
+  <subtitle>This feed represents a single publication.</subtitle><link type="application/atom+xml" rel="self" href="https://org-url:port/secure-api/v5.5/publications/12345"/>
+  <title>I am the Title of a Publication</title>
+  <author>
+    <name>Symplectic Elements at Organisation</name>
+  </author>
+  <entry>
+    <id>tag:elements@organisation,5.16:/secure-api/v5.5/publications/12345</id><category scheme="http://www.symplectic.co.uk/publications/atom/entries/" term="item" label="Item"/>
+    <updated>2020-02-03T22:35:51.08-05:00</updated><link type="application/atom+xml" rel="alternate" href="https://org-url:port/secure-api/v5.5/publications/12345"/>
+    <title>I am the Title of a Publication</title>
+    <content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p>Publication (journal article)</p>
+        <p>
+          <a href="https://org-url:port/secure-api/v5.5/publications/12345/relationships">Relationships</a>
+          with other data</p>
+      </div>
+    </content>
+    <api:object
+      category="publication"
+      id="12345"
+      last-affected-when="2020-02-03T22:35:51.08-05:00"
+      last-modified-when="2020-02-03T22:35:51.08-05:00"
+      href="https://org-url:port/secure-api/v5.5/publications/12345"
+      created-when="2017-06-23T19:41:58.97-04:00"
+      type-id="5"
+      type="journal-article">
+      <!--Publication type 5 is "journal article"-->
+      <api:ever-approved>true</api:ever-approved>
+      <api:reporting-date-1>2017-10-01</api:reporting-date-1>
+      <api:is-public>true</api:is-public>
+      <api:records>
+        <api:record format="native" id="1" source-id="2" source-name="source-1" source-display-name="Source 1" id-at-source="doi:123.45">
+          <api:native>
+            <api:field name="authors" type="person-list" display-name="Authors">
+              <api:people>
+                <api:person>
+                  <api:links><api:link type="elements/user" id="54321" href="https://org-url:port/secure-api/v5.5/users/54321"/></api:links>
+                  <api:last-name>New Author</api:last-name>
+                  <api:initials>X</api:initials>
+                  <api:first-names>Person Two</api:first-names>
+                  <api:separate-first-names>
+                    <api:first-name>Person Two</api:first-name>
+                  </api:separate-first-names>
+                </api:person>
+                <api:person>
+                  <api:links><api:link type="elements/user" id="98765" href="https://org-url:port/secure-api/v5.5/users/98765"/></api:links>
+                  <api:last-name>Author</api:last-name>
+                  <api:initials>Q</api:initials>
+                  <api:first-names>Person</api:first-names>
+                  <api:separate-first-names>
+                    <api:first-name>Person</api:first-name>
+                  </api:separate-first-names>
+                </api:person>
+              </api:people>
+            </api:field>
+            <api:field name="c-aa-match-score" type="decimal" display-name="AA Match Score">
+              <api:decimal>1</api:decimal>
+            </api:field>
+            <api:field name="confidential" type="boolean" display-name="Confidential">
+              <api:boolean>false</api:boolean>
+            </api:field>
+            <api:field name="doi" type="text" display-name="DOI">
+              <api:text>doi:123.45</api:text>
+              <api:links><api:link type="doi" href="http://doi.org/doi:123.45"/><api:link type="altmetric" href="http://www.example.com/details.php?doi=doi:123.45"/></api:links>
+            </api:field>
+            <api:field name="issn" type="text" display-name="ISSN">
+              <api:text>fake_issn</api:text>
+              <api:links><api:link type="elements/journal" href="https://org-url:port/secure-api/v5.5/journals/0000"/></api:links>
+            </api:field>
+            <api:field name="journal" type="text" display-name="Journal">
+              <api:text>A Very Important Journal</api:text>
+            </api:field>
+            <api:field name="pagination" type="pagination" display-name="Pagination">
+              <api:pagination>
+                <api:begin-page>35</api:begin-page>
+                <api:end-page>53</api:end-page>
+              </api:pagination>
+            </api:field>
+            <api:field name="publisher" type="text" display-name="Publisher">
+              <api:text>Big Publisher</api:text>
+            </api:field>
+            <api:field name="title" type="text" display-name="Title">
+              <api:text>I am the Title of a Publication</api:text>
+            </api:field>
+            <api:field name="volume" type="text" display-name="Volume">
+              <api:text>95</api:text>
+            </api:field>
+          </api:native>
+        </api:record>
+        <api:record format="native" id="2" source-id="3" source-name="source-2" source-display-name="Source 2" id-at-source="2-0000">
+          <api:citation-count>27</api:citation-count>
+          <api:native>
+            <api:field name="abstract" type="text" display-name="Abstract">
+              <api:text>This article is definitely about something.</api:text>
+            </api:field>
+            <api:field name="doi" type="text" display-name="DOI">
+              <api:text>doi:123.45</api:text>
+              <api:links><api:link type="doi" href="http://doi.org/doi:123.45"/></api:links>
+            </api:field>
+            <api:field name="issn" type="text" display-name="ISSN">
+              <api:text>fake-issn</api:text>
+              <api:links><api:link type="elements/journal" href="https://org-url:port/secure-api/v5.5/journals/0000"/></api:links>
+            </api:field>
+            <api:field name="journal" type="text" display-name="Journal">
+              <api:text>A Very Important Journal</api:text>
+            </api:field>
+            <api:field name="pagination" type="pagination" display-name="Pagination">
+              <api:pagination>
+                <api:begin-page>35</api:begin-page>
+                <api:end-page>53</api:end-page>
+              </api:pagination>
+            </api:field>
+            <api:field name="publication-status" type="text" display-name="Status">
+              <api:text>Published</api:text>
+            </api:field>
+            <api:field name="title" type="text" display-name="Title">
+              <api:text>I am the Title of a Publication</api:text>
+            </api:field>
+            <api:field name="types" type="list" display-name="Sub types">
+              <api:items>
+                <api:item>Journal Article</api:item>
+              </api:items>
+            </api:field>
+            <api:field name="volume" type="text" display-name="Volume">
+              <api:text>95</api:text>
+            </api:field>
+          </api:native>
+        </api:record>
+        <api:record format="native" id="3" source-id="13" source-name="source-3" source-display-name="Source 3" id-at-source="doi:123.45">
+          <api:native>
+            <api:field name="authors" type="person-list" display-name="Authors">
+              <api:people>
+                <api:person>
+                  <api:last-name>New Author</api:last-name>
+                  <api:initials>L</api:initials>
+                  <api:first-names>Person Two</api:first-names>
+                  <api:separate-first-names>
+                    <api:first-name>Person Two</api:first-name>
+                  </api:separate-first-names>
+                </api:person>
+                <api:person>
+                  <api:links><api:link type="elements/user" id="98765" href="https://org-url:port/secure-api/v5.5/users/98765"/></api:links>
+                  <api:last-name>Author</api:last-name>
+                  <api:initials>E</api:initials>
+                  <api:first-names>Person</api:first-names>
+                  <api:separate-first-names>
+                    <api:first-name>Person</api:first-name>
+                  </api:separate-first-names>
+                </api:person>
+              </api:people>
+            </api:field>
+            <api:field name="doi" type="text" display-name="DOI">
+              <api:text>doi:123.45</api:text>
+              <api:links><api:link type="doi" href="http://doi.org/doi:123.45"/></api:links>
+            </api:field>
+            <api:field name="issn" type="text" display-name="ISSN">
+              <api:text>fake-issn</api:text>
+              <api:links><api:link type="elements/journal" href="https://org-url:port/secure-api/v5.5/journals/0000"/></api:links>
+            </api:field>
+            <api:field name="journal" type="text" display-name="Journal">
+              <api:text>A Very Important Journal</api:text>
+            </api:field>
+            <api:field name="language" type="text" display-name="Language">
+              <api:text>en</api:text>
+            </api:field>
+            <api:field name="pagination" type="pagination" display-name="Pagination">
+              <api:pagination>
+                <api:begin-page>35</api:begin-page>
+                <api:end-page>53</api:end-page>
+              </api:pagination>
+            </api:field>
+            <api:field name="publication-status" type="text" display-name="Status">
+              <api:text>Published</api:text>
+            </api:field>
+            <api:field name="publisher" type="text" display-name="Publisher">
+              <api:text>Big Publisher</api:text>
+            </api:field>
+            <api:field name="record-created-at-source-date" type="date" display-name="Record created at source">
+              <api:date>
+                <api:day>3</api:day>
+                <api:month>5</api:month>
+                <api:year>2017</api:year>
+              </api:date>
+            </api:field>
+            <api:field name="title" type="text" display-name="Title">
+              <api:text>I am the Title of a Publication</api:text>
+            </api:field>
+            <api:field name="volume" type="text" display-name="Volume">
+              <api:text>95</api:text>
+            </api:field>
+          </api:native>
+        </api:record>
+      </api:records><api:fields/><api:relationships href="https://org-url:port/secure-api/v5.5/publications/12345/relationships"/></api:object>
+  </entry>
+</feed>

--- a/solenoid/fixtures/publication.xml
+++ b/solenoid/fixtures/publication.xml
@@ -125,8 +125,7 @@
             </api:field>
             <api:field name="publication-date" type="date" display-name="Publication date">
               <api:date>
-                <api:day>1</api:day>
-                <api:month>1</api:month>
+                <api:month>2</api:month>
                 <api:year>2017</api:year>
               </api:date>
             </api:field>


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where publication date records in Elements that are missing day or month values cause an exception in publication date parsing. Adds corresponding test.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
