### PR TITLE
Fix database migration error

### DIFF
--- a/solenoid/records/migrations/0015_auto_20200403_1856.py
+++ b/solenoid/records/migrations/0015_auto_20200403_1856.py
@@ -10,12 +10,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name='record',
-            name='message',
-            field=models.TextField(blank=True, default=''),
-            preserve_default=False,
-        ),
+        migrations.RenameField(model_name='record',
+                               old_name='message',
+                               new_name='message_old'),
+        migrations.AddField(model_name='record',
+                            name='message',
+                            field=models.TextField(blank=True, default=''),
+                            preserve_default=False),
+        migrations.RemoveField(model_name='record',
+                               name='message_old'),
         migrations.DeleteModel(
             name='Message',
         ),


### PR DESCRIPTION
#### What does this PR do?
This fixes an error in the most recent records app migration caused by altering the record.message field while updating it (a typical error in Postgres when removing null=True from a field). This fix should allow the migration to run by creating a new  message field to replace the old one instead of updating the old field directly. 

#### Helpful background context
Note that this process _will_ delete all existing message field data from the database. This will not be a problem in production, because we will coordinate the release with stakeholders to ensure that any existing citations added to the application have had emails sent. Once the emails are sent, the message field data is no longer needed, so deleting old messages from the message table (and their associations with sent emails) is fine.

#### How can a reviewer see these changes?
You should be able to revert to a previous migration, eg `python manage.py migrate records 0014_auto_20200403_1820`, manually add a record with no publisher message (message field will be NULL), and then run migration 15 without problems, `python manage.py migrate`. The message table will be deleted, and all existing records will have a blank value in the message field.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
