### PR TITLE
Update OA stats URL in email message template

### DIFF
--- a/solenoid/emails/templates/emails/author_email_template.html
+++ b/solenoid/emails/templates/emails/author_email_template.html
@@ -14,7 +14,7 @@ Subject: Paper Request for MIT Open Access Policy<br>
 </div>
 
 <p>
-  You may submit your papers by email reply, or <a href="http://libraries.mit.edu/oasubmit">use this web form</a>. We will place them in the <a href="http://dspace.mit.edu/handle/1721.1/49433">Open Access Articles collection</a> and link to the final published version.
+  You may submit your papers by email reply, or <a href="https://libraries.mit.edu/oasubmit">use this web form</a>. We will place them in the <a href="https://dspace.mit.edu/handle/1721.1/49433">Open Access Articles collection</a> and link to the final published version.
 </p>
 
 <p class="dspace-handle">
@@ -22,7 +22,7 @@ Subject: Paper Request for MIT Open Access Policy<br>
 </p>
 
 <p>
-  View download statistics for your articles and others in this collection: <a href="http://oastats.mit.edu/">http://oastats.mit.edu/</a>
+  View download statistics for your articles and others in this collection: <a href="https://dspace.mit.edu/oastats">https://dspace.mit.edu/oastats</a>
 </p>
 
 <p>


### PR DESCRIPTION
#### What does this PR do?
Replaces the old OA stats URL in the author email message with the new URL.

#### How can a reviewer see these changes?
Import some citations (or use already imported citations for which no email has been generated), create an email, and see the new URL in the message body.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
