### PR TITLE
Add timeout to Symplectic Elements requests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ import os
 
 from freezegun import freeze_time
 import pytest
+from requests.exceptions import Timeout
 import requests_mock
 
 from django.conf import settings
@@ -109,6 +110,8 @@ def mock_elements(author_xml, author_new_xml, author_pubs_xml,
         m.get('mock://api.com/409', status_code=409)
         m.get('mock://api.com/500', status_code=500)
         m.get('mock://api.com/504', status_code=504)
+        m.get('mock://api.com/timeout',
+              exc=Timeout)
         m.get('mock://api.com/page1', text=PAGE_ONE)
         m.get('mock://api.com/page2', text=PAGE_TWO)
 
@@ -146,6 +149,7 @@ def mock_elements(author_xml, author_new_xml, author_pubs_xml,
         m.patch('mock://api.com/409', status_code=409)
         m.patch('mock://api.com/500', status_code=500)
         m.patch('mock://api.com/504', status_code=504)
+        m.patch('mock://api.com/timeout', exc=Timeout)
 
         yield m
 

--- a/solenoid/elements/elements.py
+++ b/solenoid/elements/elements.py
@@ -26,7 +26,10 @@ def get_from_elements(url):
     response text. Retries up to 5 times for known Elements API retry status
     codes.
     """
-    response = requests.get(url, proxies=PROXIES, auth=AUTH)
+    response = requests.get(url,
+                            proxies=PROXIES,
+                            auth=AUTH,
+                            timeout=5)
     if response.status_code in [409, 500, 504]:
         raise RetryError(f'Elements response status {response.status_code} '
                          'requires retry')
@@ -50,7 +53,8 @@ def patch_elements_record(url, xml_data):
                               data=xml_data,
                               headers={'Content-Type': 'text/xml'},
                               proxies=PROXIES,
-                              auth=AUTH)
+                              auth=AUTH,
+                              timeout=5)
     if response.status_code in [409, 500, 504]:
         raise RetryError(f'Elements response status {response.status_code} '
                          'requires retry')

--- a/solenoid/elements/tests/test_elements.py
+++ b/solenoid/elements/tests/test_elements.py
@@ -1,5 +1,5 @@
 import pytest
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, Timeout
 
 from solenoid.elements.elements import (get_from_elements, get_paged,
                                         patch_elements_record)
@@ -22,6 +22,11 @@ def test_get_from_elements_failure_raises_exception(mock_elements):
         get_from_elements('mock://api.com/400')
 
 
+def test_get_from_elements_timeout(mock_elements):
+    with pytest.raises(Timeout):
+        get_from_elements('mock://api.com/timeout')
+
+
 def test_get_paged_success(mock_elements):
     response = get_paged('mock://api.com/page1')
     for item in response:
@@ -38,7 +43,15 @@ def test_patch_elements_record_raises_retry(mock_elements, error, patch_xml):
         patch_elements_record(error, patch_xml)
 
 
-def test_patch_elements_record_failure_raises_exception(mock_elements,
-                                                        patch_xml):
+def test_patch_elements_record_failure_raises_exception(
+    mock_elements, patch_xml
+):
     with pytest.raises(HTTPError):
         patch_elements_record('mock://api.com/400', patch_xml)
+
+
+def test_patch_elements_record_timeout(
+    mock_elements, patch_xml
+):
+    with pytest.raises(Timeout):
+        patch_elements_record('mock://api.com/timeout', patch_xml)

--- a/solenoid/records/views.py
+++ b/solenoid/records/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, Timeout
 
 from django.conf import settings
 from django.contrib import messages
@@ -184,6 +184,13 @@ class Import(ConditionalLoginRequiredMixin, FormView):
                        'Please confirm the Elements ID and try again.')
                 messages.warning(self.request, msg)
                 return super(Import, self).form_invalid(form)
+        except Timeout as e:
+            logger.info(e)
+            msg = ('Unable to connect to Symplectic '
+                   'Elements. Please wait a few '
+                   'minutes and try again.')
+            messages.warning(self.request, msg)
+            return super(Import, self).form_invalid(form)
         author_data = parse_author_xml(author_xml)
         pub_ids = parse_author_pubs_xml(
             get_paged(f'{author_url}/publications?&detail=full'), author_data)


### PR DESCRIPTION
#### What does this PR do?
Adds a timeout of 5 seconds to all SE requests and handles timeout exceptions with a user-facing message informing them of the issue.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
