### PR TITLE
Return response text in patch elements call

### DIFF
--- a/solenoid/elements/elements.py
+++ b/solenoid/elements/elements.py
@@ -59,4 +59,4 @@ def patch_elements_record(url, xml_data):
         raise RetryError(f'Elements response status {response.status_code} '
                          'requires retry')
     response.raise_for_status()
-    return response
+    return response.text

--- a/solenoid/elements/tests/test_elements.py
+++ b/solenoid/elements/tests/test_elements.py
@@ -34,8 +34,8 @@ def test_get_paged_success(mock_elements):
 
 
 def test_patch_elements_record_success(mock_elements, patch_xml):
-    response = patch_elements_record('mock://api.com', patch_xml)
-    assert 200 == response.status_code
+    response_text = patch_elements_record('mock://api.com', patch_xml)
+    assert 'Success' == response_text
 
 
 def test_patch_elements_record_raises_retry(mock_elements, error, patch_xml):


### PR DESCRIPTION
#### What does this PR do?
The patch elements function was returning the response object from Elements, but task values now need to be json-serializable, so this was raising an error. The task was still functioning correctly, it just raised the error on the return value. This PR changes the return value to the response text instead of the response object, since the text is json-serializable.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
