### PR TITLE
Replace deprecated functions in preparation for upgrade to Django 4.0

### DIFF
--- a/solenoid/elements/__init__.py
+++ b/solenoid/elements/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'solenoid.elements.apps.ElementsConfig'

--- a/solenoid/emails/__init__.py
+++ b/solenoid/emails/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'solenoid.emails.apps.EmailsConfig'

--- a/solenoid/emails/signals.py
+++ b/solenoid/emails/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
-email_sent = Signal(providing_args=['instance', 'username'])
+# providing_args=['instance', 'username']
+email_sent = Signal()

--- a/solenoid/emails/urls.py
+++ b/solenoid/emails/urls.py
@@ -1,16 +1,16 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'emails'
 
 urlpatterns = [
-    url(r'^create/$', views.EmailCreate.as_view(), name='create'),
-    url(r'^(?P<pk>\d+)/$', views.EmailEvaluate.as_view(), name='evaluate'),
-    url(r'^send/$', views.EmailSend.as_view(), name='send'),
-    url(r'^$', views.EmailListPending.as_view(), name='list_pending'),
-    url(r'^liaison/(?P<pk>\d+)/$', views.EmailLiaison.as_view(),
-        name='get_liaison'),
-    url(r'^rebuild/(?P<pk>\d+)/$', views.EmailRebuild.as_view(),
-        name='rebuild'),
-]
+    re_path(r'^create/$', views.EmailCreate.as_view(), name='create'),
+    re_path(r'^(?P<pk>\d+)/$', views.EmailEvaluate.as_view(), name='evaluate'),
+    re_path(r'^send/$', views.EmailSend.as_view(), name='send'),
+    re_path(r'^$', views.EmailListPending.as_view(), name='list_pending'),
+    re_path(r'^liaison/(?P<pk>\d+)/$', views.EmailLiaison.as_view(),
+            name='get_liaison'),
+    re_path(r'^rebuild/(?P<pk>\d+)/$', views.EmailRebuild.as_view(),
+            name='rebuild'),
+    ]

--- a/solenoid/people/urls.py
+++ b/solenoid/people/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'people'
 
 urlpatterns = [
-    url(r'^new$', views.LiaisonCreate.as_view(), name='liaison_create'),
-    url(r'^$', views.LiaisonList.as_view(), name='liaison_list'),
-    url(r'^(?P<pk>\d+)/$', views.LiaisonUpdate.as_view(),
-        name='liaison_update'),
-    url(r'^delete/(?P<pk>\d+)/$', views.LiaisonDelete.as_view(),
-        name='liaison_delete'),
-]
+    re_path(r'^new$', views.LiaisonCreate.as_view(), name='liaison_create'),
+    re_path(r'^$', views.LiaisonList.as_view(), name='liaison_list'),
+    re_path(r'^(?P<pk>\d+)/$', views.LiaisonUpdate.as_view(),
+            name='liaison_update'),
+    re_path(r'^delete/(?P<pk>\d+)/$', views.LiaisonDelete.as_view(),
+            name='liaison_delete'),
+    ]

--- a/solenoid/records/urls.py
+++ b/solenoid/records/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.generic import TemplateView
 
 from . import views
@@ -6,10 +6,11 @@ from . import views
 app_name = 'records'
 
 urlpatterns = [
-    url(r'^$', views.UnsentList.as_view(), name='unsent_list'),
-    url(r'^import/$', views.Import.as_view(), name='import'),
-    url(r'^import/status/(?P<task_id>[^/]+)/$', views.status, name="status"),
-    url(r'^instructions/$',
-        TemplateView.as_view(template_name="records/instructions.html"),
-        name='instructions'),
-]
+    re_path(r'^$', views.UnsentList.as_view(), name='unsent_list'),
+    re_path(r'^import/$', views.Import.as_view(), name='import'),
+    re_path(r'^import/status/(?P<task_id>[^/]+)/$', views.status,
+            name="status"),
+    re_path(r'^instructions/$',
+            TemplateView.as_view(template_name="records/instructions.html"),
+            name='instructions'),
+    ]

--- a/solenoid/urls.py
+++ b/solenoid/urls.py
@@ -13,8 +13,8 @@ Including another URLconf
     1. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, re_path
 from django.views.defaults import server_error
 
 from solenoid.userauth.views import SolenoidLogoutView
@@ -22,23 +22,24 @@ from solenoid.userauth.views import SolenoidLogoutView
 from .views import HomeView
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^$', HomeView.as_view(), name='home'),
-    url(r'^celery-progress/', include('celery_progress.urls',
-                                      namespace='celery_progress')),
-    url(r'^records/', include('solenoid.records.urls', namespace='records')),
-    url(r'^emails/', include('solenoid.emails.urls', namespace='emails')),
-    url(r'^people/', include('solenoid.people.urls', namespace='people')),
-    url(r'^oauth2/', include('social_django.urls', namespace='social')),
-    url(r'^logout/$',
-        SolenoidLogoutView.as_view(template_name='userauth/logout.html'),
-        name='logout'),
-    url(r'^500/$', server_error),
-]
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^$', HomeView.as_view(), name='home'),
+    re_path(r'^celery-progress/', include('celery_progress.urls',
+                                          namespace='celery_progress')),
+    re_path(r'^records/', include('solenoid.records.urls',
+                                  namespace='records')),
+    re_path(r'^emails/', include('solenoid.emails.urls', namespace='emails')),
+    re_path(r'^people/', include('solenoid.people.urls', namespace='people')),
+    re_path(r'^oauth2/', include('social_django.urls', namespace='social')),
+    re_path(r'^logout/$',
+            SolenoidLogoutView.as_view(template_name='userauth/logout.html'),
+            name='logout'),
+    re_path(r'^500/$', server_error),
+    ]
 
 
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
+        re_path(r'^__debug__/', include(debug_toolbar.urls)),
+        ] + urlpatterns


### PR DESCRIPTION
#### What does this PR do?
Django 4.0 removes a few functions used in the app, we have been seeing these warnings for some time but need to deal with them if we want to upgrade the Django version, which we will want to do when it is released. Thsi PR replaces the deprecated functions with appropriate functions for Django 4.0, based on the pytest warnings.

Note that there are still deprecation warnings but they are all from external packages that have not yet been updated in preparation for  Django 4.0 (most of these do have updates on their dev branches, they just haven't been released yet). These will be updated as soon as they are available.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
