### PR TITLE
Remove form link from email template

### DIFF
--- a/solenoid/emails/templates/emails/author_email_template.html
+++ b/solenoid/emails/templates/emails/author_email_template.html
@@ -14,7 +14,7 @@ Subject: Paper Request for MIT Open Access Policy<br>
 </div>
 
 <p>
-  You may submit your papers by email reply, or <a href="https://libraries.mit.edu/oasubmit">use this web form</a>. We will place them in the <a href="https://dspace.mit.edu/handle/1721.1/49433">Open Access Articles collection</a> and link to the final published version.
+  You may submit your papers by email reply. We will deposit them in the <a href="https://dspace.mit.edu/handle/1721.1/49433">Open Access Articles collection</a> and link to the final published version. 
 </p>
 
 <p class="dspace-handle">


### PR DESCRIPTION
#### What does this PR do?
Per request from the OA team, change the wording on the author email template to remove the link to the submission form. They no longer want authors to submit via that form, but instead to simply send papers by email.

#### How can a reviewer see these changes?
It's a pain. You can run the app locally while connected to the Cisco VPN (ensuring that you have all the right ENV for local development, particularly the Elements login info) and import an author's papers (12512 is a sample author ID you can use for importing). Then create an email from the citations and look at the email text to see that the new template is used.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [ ] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified