### PR TITLE
Extend character limit on record model fields

### DIFF
--- a/solenoid/records/models.py
+++ b/solenoid/records/models.py
@@ -33,19 +33,19 @@ class Record(models.Model):
         blank=True,
         null=True,
         on_delete=models.CASCADE)
-    publisher_name = models.CharField(max_length=75)
+    publisher_name = models.CharField(max_length=255)
     acq_method = models.CharField(
-        max_length=32,
+        max_length=255,
         blank=True)
     citation = models.TextField()
-    doi = models.CharField(max_length=45, blank=True)
+    doi = models.CharField(max_length=255, blank=True)
     # This is the unique ID within Elements, which is NOT the same as the
     # proprietary data source ID - those are unique IDs within Scopus, Web of
     # Science, etc. We may have multiple records with the same paper ID
     # because there will be one record per author (hence the unique_together
     # constraint). The unique ID on pubdata-dev does not match that on the
     # production server.
-    paper_id = models.CharField(max_length=10)
+    paper_id = models.CharField(max_length=255)
     message = models.TextField(blank=True)
 
     def __str__(self):


### PR DESCRIPTION
#### What does this PR do?
There was previously an arbitrarily short character limit of 45 on the Record model `doi` CharField. DOIs do not have a character limit restriction, and we did in fact encounter errors when attempting to import papers with DOIs longer than 45 characters. This resolves the errors by:
* Extending character limit on `Record.doi` field to 255 characters
* Also extends the (similarly arbitrarily short) character limit on a few other fields in the Record model

Note: tests have not been updated because SQLite (which is used for the test database) does not enforce the max_length property on VARCHAR fields, so adding a test for this would be pointless as it will pass regardless of DOI length or max_length setting.

#### How can a reviewer see these changes?
Unfortunately you can't really, as SQLite is used for the local development database and it doesn't enforce the max_length restriction on Charfields (see note about tests above), and we can't import data from Elements on PR builds because the dev server is IP-restricted (we only have static IPs for staging and production builds on Heroku). However, this change will be verified on staging after merge and before promoting to production.

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [x] The commit message is clear and follows our guidelines
- NA There are tests covering any new functionality
- NA The documentation has been updated if necessary
- NA The changes, if applicable, have been verified