### PR TITLE
Increase request and connection pool limits

### DIFF
--- a/solenoid/elements/elements.py
+++ b/solenoid/elements/elements.py
@@ -20,16 +20,13 @@ PROXIES = {
 }
 
 
-@backoff.on_exception(backoff.expo, RetryError, max_tries=3)
+@backoff.on_exception(backoff.expo, RetryError, max_tries=5)
 def get_from_elements(url):
     """Issue a get request to the Elements API for a given URL. Return the
     response text. Retries up to 5 times for known Elements API retry status
     codes.
     """
-    response = requests.get(url,
-                            proxies=PROXIES,
-                            auth=AUTH,
-                            timeout=5)
+    response = requests.get(url, proxies=PROXIES, auth=AUTH, timeout=10)
     if response.status_code in [409, 500, 504]:
         raise RetryError(f'Elements response status {response.status_code} '
                          'requires retry')
@@ -46,15 +43,19 @@ def get_paged(url):
         yield from get_paged(url)
 
 
+@backoff.on_exception(backoff.expo, RetryError, max_tries=5)
 def patch_elements_record(url, xml_data):
     """Issue a patch to the Elements API for a given item record URL, with the
-    given update data. Return the response."""
-    response = requests.patch(url,
-                              data=xml_data,
-                              headers={'Content-Type': 'text/xml'},
-                              proxies=PROXIES,
-                              auth=AUTH,
-                              timeout=5)
+    given update data. Return the response. Retries up to 5 times for known Elements
+    API retry status codes."""
+    response = requests.patch(
+        url,
+        data=xml_data,
+        headers={"Content-Type": "text/xml"},
+        proxies=PROXIES,
+        auth=AUTH,
+        timeout=10,
+    )
     if response.status_code in [409, 500, 504]:
         raise RetryError(f'Elements response status {response.status_code} '
                          'requires retry')

--- a/solenoid/elements/tests/test_elements.py
+++ b/solenoid/elements/tests/test_elements.py
@@ -14,7 +14,7 @@ def test_get_from_elements_success(mock_elements):
 def test_get_from_elements_retries_and_raises_exception(mock_elements, error):
     with pytest.raises(RetryError):
         get_from_elements(error)
-    assert mock_elements.call_count == 3
+    assert mock_elements.call_count == 5
 
 
 def test_get_from_elements_failure_raises_exception(mock_elements):

--- a/solenoid/settings/base.py
+++ b/solenoid/settings/base.py
@@ -425,7 +425,12 @@ INSTALLED_APPS += ['celery_progress']
 
 CELERY_BROKER_URL = os.getenv('REDIS_URL',
                               default='redis://localhost:6379/0')
-CELERY_BROKER_TRANSPORT_OPTIONS = {"max_retries": 3, "interval_start": 0,
-                                   "interval_step": 0.2, "interval_max": 0.5}
 CELERY_RESULT_BACKEND = os.getenv('REDIS_URL',
                                   default='redis://localhost:6379')
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    "max_retries": 5,
+    "interval_start": 0,
+    "interval_step": 0.2,
+    "interval_max": 0.5,
+    "max_connections": 20,
+}


### PR DESCRIPTION
#### What does this PR do?
A recent issue with Symplectic Elements caused slow responses to the Solenoid patch api calls. This ended up spiking our Redis connections as the task backlogged increased while trying to work through the errors. Two issues were at play here: 1) not handling slow response times from Elements and 2) not limiting the number of connections to our Redis instance.

Changes:
* Increases the max retry and timeout limits for all Elements API calls, to account for possible slowness on the Elements server
* Sets a max_connection limit for the Redis connection pool to ensure that we don't go past our account limit
* Updates relevant tests

#### Side effects of this change:
None, but if these changes don't resolve the issue we will need to consider 1) raising a ticket with Elements if the slow sever response continues, and/or 2) upping our Heroku Redis plan to allow for more simultaneous connections

#### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/INFRA-190

#### Includes new or updated dependencies?
NO

#### Reviewer checklist
- [x] The commit message is clear and follows our guidelines
- [x] There are tests covering any new functionality
- [x] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
